### PR TITLE
Add option for assigning static webpack dev server port number.

### DIFF
--- a/Rimutec.AspNetCore.SpaServices.Extensions/WebpackDevelopmentServer/WebpackDevelopmentServerMiddlewareExtensions.cs
+++ b/Rimutec.AspNetCore.SpaServices.Extensions/WebpackDevelopmentServer/WebpackDevelopmentServerMiddlewareExtensions.cs
@@ -16,9 +16,15 @@ namespace RimuTec.AspNetCore.SpaServices.WebpackDevelopmentServer
     /// </summary>
     public static class WebpackDevelopmentServerMiddlewareExtensions
     {
+        /// <summary>
+        /// Starts SPA application dev server by running provided npm command.
+        /// </summary>
+        /// <param name="npmScriptName">Name of the npm command to run</param>
+        /// <param name="devServerPortNumber">Port number for the webpack dev server. If not provided randon unused port number will be assigned automatically.</param>
         public static void UseWebpackDevelopmentServer(
             this ISpaBuilder spaBuilder,
-            string npmScriptName
+            string npmScriptName,
+            int? devServerPortNumber = null
             )
         {
             if (spaBuilder == null)
@@ -30,7 +36,7 @@ namespace RimuTec.AspNetCore.SpaServices.WebpackDevelopmentServer
 
             var spaOptions = spaBuilder.Options;
 
-            if(string.IsNullOrEmpty(spaOptions.SourcePath))
+            if (string.IsNullOrEmpty(spaOptions.SourcePath))
             {
 #pragma warning disable CA1303 // Do not pass literals as localized parameters
                 throw new InvalidOperationException($"To use {nameof(UseWebpackDevelopmentServer)}, " +
@@ -39,7 +45,7 @@ namespace RimuTec.AspNetCore.SpaServices.WebpackDevelopmentServer
 #pragma warning restore CA1303 // Do not pass literals as localized parameters
             }
 
-            WebpackDevelopmentServerMiddleware.Attach(spaBuilder, npmScriptName);
+            WebpackDevelopmentServerMiddleware.Attach(spaBuilder, npmScriptName, devServerPortNumber);
         }
     }
 }


### PR DESCRIPTION
By default this package uses random available port number for webpack dev server using ` TcpPortFinder.FindAvailablePort();`. 

This PR adds an option for specifying the port manually. You can provide an additional argument to `UseWebpackDevelopmentServer` with the port number to bypass `FindAvailablePort()`:

    spa.UseWebpackDevelopmentServer(npmScriptName: "serve", devServerPortNumber: 9999);

Changes are backwards compatible, so by default it works as before.